### PR TITLE
Refactor/Mapper

### DIFF
--- a/src/main/java/com/ros/lms/application/BookServiceImpl.java
+++ b/src/main/java/com/ros/lms/application/BookServiceImpl.java
@@ -13,6 +13,7 @@ import com.ros.lms.ports.outbound.repository_contracts.AuthorDAO;
 import com.ros.lms.ports.outbound.repository_contracts.BookDAO;
 import com.ros.lms.ports.outbound.repository_contracts.GenreDAO;
 import com.ros.lms.ports.outbound.repository_contracts.StaffDAO;
+import com.ros.lms.util.Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
@@ -25,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +36,7 @@ public class BookServiceImpl implements BookService {
     private final GenreDAO genreDAO;
     private final StaffDAO staffDAO;
     private final StorageService storageService;
+    private final Mapper mapper;
     private static final int MAX_PAGE_SIZE = 100;
 
     @Autowired
@@ -44,13 +45,15 @@ public class BookServiceImpl implements BookService {
             @Qualifier("authorDAOJpaImpl") AuthorDAO authorDAO,
             @Qualifier("genreDAOJpaImpl") GenreDAO genreDAO,
             @Qualifier("staffDAOJpaImpl") StaffDAO staffDAO,
-            StorageService storageService
+            StorageService storageService,
+            Mapper mapper
     ){
         this.bookDAO = bookDAO;
         this.authorDAO = authorDAO;
         this.genreDAO = genreDAO;
         this.staffDAO = staffDAO;
         this.storageService = storageService;
+        this.mapper = mapper;
     }
 
     @Transactional
@@ -67,7 +70,7 @@ public class BookServiceImpl implements BookService {
             throw new StaffNotFoundException("Staff not found with username: " + addBookDTO.staffUsername());
 
         // Map the DTO to a Book entity
-        Book book = addBookMapper.apply(addBookDTO);
+        Book book = mapper.addBookDtoToBook.apply(addBookDTO);
         Set<AuthorDTO> authors = parseAuthors(addBookDTO.authors());
 
         associateAuthorsWithBook(authors, book);
@@ -132,19 +135,16 @@ public class BookServiceImpl implements BookService {
                 searchBookDTO.isAvailable(),
                 pageable);
 
-        return bookPage.map(bookDTOMapper);
+        return bookPage.map(mapper.bookToBookDto);
     }
 
     @Cacheable(value = "bookByIsbnCache", key = "#isbn")
     @Override
     public Optional<BookDTO> getByIsbn(String isbn) throws BookNotFoundException {
         return Optional.ofNullable(bookDAO.findByISBN(isbn)
-                .map(bookDTOMapper)
+                .map(mapper.bookToBookDto)
                 .orElseThrow(() -> new BookNotFoundException("Book with ISBN '" + isbn + "' was not found.")));
     }
-
-    private final Function<AddBookDTO, Book> addBookMapper = addBookDTO ->
-            new Book(addBookDTO.isbn(), addBookDTO.title(), true);
 
     private Set<AuthorDTO> parseAuthors(String authorsString) {
         return Arrays.stream(authorsString.split(","))
@@ -163,35 +163,6 @@ public class BookServiceImpl implements BookService {
                 .map(String::trim)
                 .collect(Collectors.toSet());
     }
-
-    private final Function<Author, AuthorDTO> authorDTOMapper =
-            entity -> new AuthorDTO(entity.getFirstName(), entity.getLastName());
-
-    private final Function<Book, BookDTO> bookDTOMapper = entity -> {
-
-        Set<AuthorDTO> authors = Optional.ofNullable(entity.getAuthors())
-                .orElse(List.of())
-                .stream()
-                .map(authorDTOMapper)
-                .collect(Collectors.toSet());
-
-
-        Set<GenreType> genres = Optional.ofNullable(entity.getGenres())
-                .orElse(List.of())
-                .stream()
-                .map(Genre::getLabel)
-                .collect(Collectors.toSet());
-
-        return new BookDTO(
-                entity.getId(),
-                entity.getIsbn(),
-                entity.getTitle(),
-                authors,
-                genres,
-                entity.isAvailable(),
-                entity.getCoverImagePath()
-                );
-    };
 
     private void associateAuthorsWithBook(Set<AuthorDTO> authors, Book book) {
         for (AuthorDTO authorDTO : authors) {

--- a/src/main/java/com/ros/lms/application/MemberServiceImpl.java
+++ b/src/main/java/com/ros/lms/application/MemberServiceImpl.java
@@ -14,6 +14,7 @@ import com.ros.lms.ports.outbound.repository_contracts.AuthorityTypeDAO;
 import com.ros.lms.ports.outbound.repository_contracts.MemberDAO;
 import com.ros.lms.ports.outbound.repository_contracts.StaffDAO;
 import com.ros.lms.ports.outbound.repository_contracts.UserDAO;
+import com.ros.lms.util.Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,6 +31,7 @@ public class MemberServiceImpl implements MemberService {
     private final StaffDAO staffDAO;
     private final AuthorityTypeDAO authorityTypeDAO;
     private final PasswordEncoder passwordEncoder;
+    private final Mapper mapper;
 
     @Autowired
     public MemberServiceImpl(
@@ -37,13 +39,15 @@ public class MemberServiceImpl implements MemberService {
             @Qualifier("userDAOJpaImpl") UserDAO userDAO,
             @Qualifier("staffDAOJpaImpl") StaffDAO staffDAO,
             @Qualifier("authorityTypeDAOJpaImpl") AuthorityTypeDAO authorityTypeDAO,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            Mapper mapper
     ) {
         this.memberDAO = memberDAO;
         this.userDAO = userDAO;
         this.staffDAO = staffDAO;
         this.authorityTypeDAO = authorityTypeDAO;
         this.passwordEncoder = passwordEncoder;
+        this.mapper = mapper;
     }
 
 
@@ -66,41 +70,8 @@ public class MemberServiceImpl implements MemberService {
         AuthorityType memberRole = authorityTypeDAO.findByLabel(RoleType.MEMBER)
                 .orElseThrow(() -> new IllegalStateException("Role MEMBER not found in DB"));
 
-        User user = userMapper(dto, memberRole);
+        User user = mapper.AddMemberDtoToUser(dto, memberRole, passwordEncoder);
         userDAO.create(user);
-        memberDAO.create(memberMapper(dto, user));
-    }
-
-    private Member memberMapper(AddMemberDTO dto, User user){
-        String[] nameParts = dto.firstName().split(" ", 2);
-        String firstName = nameParts[0];
-        String middleName = nameParts.length > 1 ? nameParts[1] : null;
-
-        Member member = new Member.Builder()
-                .governmentID(dto.governmentID())
-                .user(user)
-                .firstName(firstName)
-                .lastName(dto.lastName())
-                .phone(dto.phone())
-                .dateOfBirth(dto.dateOfBirth())
-                .sex(dto.sex())
-                .build();
-
-        if(middleName != null)
-            member.setMiddleName(middleName);
-
-        return member;
-    }
-
-    private User userMapper(AddMemberDTO dto, AuthorityType authorityType){
-        User user = new User();
-        user.setUsername(dto.username());
-        user.setEmail(dto.email());
-        String hashedPassword = passwordEncoder.encode(dto.password());
-        user.setPassword(hashedPassword);
-        user.setEnabled(true);
-        Set<AuthorityType> authorities = Set.of(authorityType);
-        user.setAuthorities(authorities);
-        return user;
+        memberDAO.create(mapper.AddMemberDtoToMember(dto, user));
     }
 }

--- a/src/main/java/com/ros/lms/util/Mapper.java
+++ b/src/main/java/com/ros/lms/util/Mapper.java
@@ -1,0 +1,87 @@
+package com.ros.lms.util;
+
+import com.ros.lms.domain.dtos.AddBookDTO;
+import com.ros.lms.domain.dtos.AddMemberDTO;
+import com.ros.lms.domain.dtos.AuthorDTO;
+import com.ros.lms.domain.dtos.BookDTO;
+import com.ros.lms.domain.entities.*;
+import com.ros.lms.domain.enums.GenreType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class Mapper {
+
+    public final Function<AddBookDTO, Book> addBookDtoToBook = addBookDTO ->
+            new Book(addBookDTO.isbn(), addBookDTO.title(), true);
+
+    private final Function<Author, AuthorDTO> authorToAuthorDto =
+            entity -> new AuthorDTO(entity.getFirstName(), entity.getLastName());
+
+    public final Function<Book, BookDTO> bookToBookDto = entity -> {
+
+        Set<AuthorDTO> authors = Optional.ofNullable(entity.getAuthors())
+                .orElse(List.of())
+                .stream()
+                .map(authorToAuthorDto)
+                .collect(Collectors.toSet());
+
+
+        Set<GenreType> genres = Optional.ofNullable(entity.getGenres())
+                .orElse(List.of())
+                .stream()
+                .map(Genre::getLabel)
+                .collect(Collectors.toSet());
+
+        return new BookDTO(
+                entity.getId(),
+                entity.getIsbn(),
+                entity.getTitle(),
+                authors,
+                genres,
+                entity.isAvailable(),
+                entity.getCoverImagePath()
+        );
+    };
+
+    public Member AddMemberDtoToMember(AddMemberDTO dto, User user){
+        String[] nameParts = dto.firstName().split(" ", 2);
+        String firstName = nameParts[0];
+        String middleName = nameParts.length > 1 ? nameParts[1] : null;
+
+        Member member = new Member.Builder()
+                .governmentID(dto.governmentID())
+                .user(user)
+                .firstName(firstName)
+                .lastName(dto.lastName())
+                .phone(dto.phone())
+                .dateOfBirth(dto.dateOfBirth())
+                .sex(dto.sex())
+                .build();
+
+        if(middleName != null)
+            member.setMiddleName(middleName);
+
+        return member;
+    }
+
+    public User AddMemberDtoToUser(AddMemberDTO dto, AuthorityType authorityType, PasswordEncoder passwordEncoder){
+        User user = new User();
+        user.setUsername(dto.username());
+        user.setEmail(dto.email());
+        String hashedPassword = passwordEncoder.encode(dto.password());
+        user.setPassword(hashedPassword);
+        user.setEnabled(true);
+        Set<AuthorityType> authorities = Set.of(authorityType);
+        user.setAuthorities(authorities);
+        return user;
+    }
+
+
+}

--- a/src/test/java/com/ros/lms/application/BookServiceTest.java
+++ b/src/test/java/com/ros/lms/application/BookServiceTest.java
@@ -14,6 +14,7 @@ import com.ros.lms.ports.outbound.repository_contracts.AuthorDAO;
 import com.ros.lms.ports.outbound.repository_contracts.BookDAO;
 import com.ros.lms.ports.outbound.repository_contracts.GenreDAO;
 import com.ros.lms.ports.outbound.repository_contracts.StaffDAO;
+import com.ros.lms.util.Mapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -58,6 +59,9 @@ public class BookServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        Mapper mapper = new Mapper();
+        bookService = new BookServiceImpl(bookDAO, authorDAO, genreDAO, staffDAO, storageService, mapper);
+
         coverImage = new MockMultipartFile(
                 "coverImage",
                 "cover.jpg",

--- a/src/test/java/com/ros/lms/application/MemberServiceTest.java
+++ b/src/test/java/com/ros/lms/application/MemberServiceTest.java
@@ -15,6 +15,7 @@ import com.ros.lms.ports.outbound.repository_contracts.AuthorityTypeDAO;
 import com.ros.lms.ports.outbound.repository_contracts.MemberDAO;
 import com.ros.lms.ports.outbound.repository_contracts.StaffDAO;
 import com.ros.lms.ports.outbound.repository_contracts.UserDAO;
+import com.ros.lms.util.Mapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -54,6 +55,8 @@ public class MemberServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        Mapper mapper = new Mapper();
+        memberService = new MemberServiceImpl(memberDAO, userDAO, staffDAO, authorityTypeDAO, passwordEncoder, mapper);
 
         // Create a sample AddMemberDTO
         validMemberDtoWithMiddleName = new AddMemberDTO(


### PR DESCRIPTION
This PR refactors some service implementation classes to centralize all mapping logic in the Mapper component. Previously, mapping between DTOs and entities was scattered across the services, making the code harder to maintain and test.